### PR TITLE
feat: deterministic topological sort

### DIFF
--- a/packages/object/src/hashgraph/index.ts
+++ b/packages/object/src/hashgraph/index.ts
@@ -5,6 +5,8 @@ import { BitSet } from "./bitset.js";
 import { linearizeMultipleSemantics } from "../linearize/multipleSemantics.js";
 import { linearizePairSemantics } from "../linearize/pairSemantics.js";
 import type { Vertex_Operation as Operation, Vertex } from "../proto/drp/object/v1/object_pb.js";
+import { Heap } from "../utils/heap.js";
+import { MinHeap } from "../utils/minHeap.js";
 import { ObjectSet } from "../utils/objectSet.js";
 
 // Reexporting the Vertex and Operation types from the protobuf file
@@ -227,7 +229,7 @@ export class HashGraph {
 	kahnsAlgorithm(origin: Hash, subgraph: ObjectSet<Hash>): Hash[] {
 		const result: Hash[] = [];
 		const inDegree = new Map<Hash, number>();
-		const queue: Hash[] = [];
+		const queue: Heap<Hash> = new Heap(new MinHeap());
 
 		for (const hash of subgraph.entries()) {
 			inDegree.set(hash, 0);
@@ -241,11 +243,9 @@ export class HashGraph {
 			}
 		}
 
-		let head = 0;
 		queue.push(origin);
-		while (queue.length > 0) {
-			const current = queue[head];
-			head++;
+		while (queue.length() > 0) {
+			const current = queue.pop();
 			if (!current) continue;
 
 			result.push(current);
@@ -257,11 +257,6 @@ export class HashGraph {
 				if (inDegreeValue - 1 === 0) {
 					queue.push(child);
 				}
-			}
-
-			if (head > queue.length / 2) {
-				queue.splice(0, head);
-				head = 0;
 			}
 		}
 

--- a/packages/object/src/utils/heap.ts
+++ b/packages/object/src/utils/heap.ts
@@ -1,0 +1,69 @@
+export interface HeapInterface<T> {
+	length(): number;
+	less(i: number, j: number): boolean;
+	swap(i: number, j: number): void;
+	push(item: T): void;
+	pop(): T | undefined;
+}
+
+export class Heap<T> {
+	private readonly _heap: HeapInterface<T>;
+
+	constructor(heap: HeapInterface<T>) {
+		this._heap = heap;
+	}
+
+	length(): number {
+		return this._heap.length();
+	}
+
+	push(item: T): void {
+		this._heap.push(item);
+		this._up(this._heap.length() - 1);
+	}
+
+	pop(): T | undefined {
+		const n = this._heap.length() - 1;
+		if (n < 0) return undefined;
+		this._heap.swap(0, n);
+		this._down(0, n);
+		return this._heap.pop();
+	}
+
+	remove(i: number): T | undefined {
+		const n = this._heap.length() - 1;
+		if (n !== i) {
+			this._heap.swap(i, n);
+			if (!this._down(i, n)) this._up(i);
+		}
+		return this._heap.pop();
+	}
+
+	private _up(j: number): void {
+		while (true) {
+			const parent = j > 0 ? Math.floor((j - 1) / 2) : 0;
+			if (parent === j || !this._heap.less(j, parent)) break;
+			this._heap.swap(parent, j);
+			j = parent;
+		}
+	}
+
+	private _down(i0: number, n: number): boolean {
+		let i = i0;
+		while (true) {
+			const left = 2 * i + 1;
+			if (left >= n) break;
+
+			let j = left;
+			const right = left + 1;
+			if (right < n && this._heap.less(right, left)) {
+				j = right;
+			}
+			if (!this._heap.less(j, i)) break;
+			this._heap.swap(i, j);
+			i = j;
+		}
+
+		return i > i0;
+	}
+}

--- a/packages/object/src/utils/minHeap.ts
+++ b/packages/object/src/utils/minHeap.ts
@@ -1,0 +1,26 @@
+import { HeapInterface } from "./heap.js";
+import { Hash } from "../hashgraph/index.js";
+
+export class MinHeap implements HeapInterface<Hash> {
+	private readonly heap: Hash[] = [];
+
+	length(): number {
+		return this.heap.length;
+	}
+
+	push(item: Hash): void {
+		this.heap.push(item);
+	}
+
+	pop(): Hash | undefined {
+		return this.heap.pop();
+	}
+
+	less(i: number, j: number): boolean {
+		return this.heap[i] < this.heap[j];
+	}
+
+	swap(i: number, j: number): void {
+		[this.heap[i], this.heap[j]] = [this.heap[j], this.heap[i]];
+	}
+}

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -1,9 +1,13 @@
 import { MapConflictResolution, MapDRP } from "@ts-drp/blueprints/src/Map/index.js";
 import { SetDRP } from "@ts-drp/blueprints/src/Set/index.js";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { ObjectACL } from "../src/acl/index.js";
 import { ACLGroup, DRPObject, DrpType, type Operation, OperationType } from "../src/index.js";
+
+vi.useFakeTimers({
+	now: new Date(1738164958),
+});
 
 const acl = new ObjectACL({
 	admins: new Map([

--- a/packages/object/tests/heap.test.ts
+++ b/packages/object/tests/heap.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "vitest";
+
+import { Heap } from "../src/utils/heap.js";
+import { MinHeap } from "../src/utils/minHeap.js";
+
+describe("Heap", () => {
+	test("MinHeap basic operations", () => {
+		const heap = new Heap(new MinHeap());
+
+		heap.push("a");
+		heap.push("b");
+		heap.push("c");
+
+		expect(heap.length()).toBe(3);
+		expect(heap.pop()).toBe("a");
+		expect(heap.pop()).toBe("b");
+		expect(heap.pop()).toBe("c");
+		expect(heap.pop()).toBeUndefined();
+	});
+
+	test("MinHeap with unordered insertions", () => {
+		const heap = new Heap(new MinHeap());
+
+		heap.push("c");
+		heap.push("a");
+		heap.push("b");
+
+		expect(heap.pop()).toBe("a");
+		expect(heap.pop()).toBe("b");
+		expect(heap.pop()).toBe("c");
+	});
+
+	test("MinHeap with duplicates", () => {
+		const heap = new Heap(new MinHeap());
+
+		heap.push("b");
+		heap.push("a");
+		heap.push("b");
+		heap.push("a");
+
+		expect(heap.pop()).toBe("a");
+		expect(heap.pop()).toBe("a");
+		expect(heap.pop()).toBe("b");
+		expect(heap.pop()).toBe("b");
+	});
+
+	test("MinHeap remove operation", () => {
+		const heap = new Heap(new MinHeap());
+
+		heap.push("d");
+		heap.push("b");
+		heap.push("a");
+		heap.push("c");
+
+		expect(heap.remove(1)).toBe("c");
+		expect(heap.pop()).toBe("a");
+		expect(heap.pop()).toBe("b");
+		expect(heap.pop()).toBe("d");
+	});
+
+	test("MinHeap edge cases", () => {
+		const heap = new Heap(new MinHeap());
+
+		// Empty heap operations
+		expect(heap.length()).toBe(0);
+		expect(heap.pop()).toBeUndefined();
+		expect(heap.remove(0)).toBeUndefined();
+
+		// Single element
+		heap.push("a");
+		expect(heap.length()).toBe(1);
+		expect(heap.pop()).toBe("a");
+		expect(heap.length()).toBe(0);
+
+		// Push after empty
+		heap.push("b");
+		expect(heap.pop()).toBe("b");
+	});
+
+	test("MinHeap with special characters", () => {
+		const heap = new Heap(new MinHeap());
+
+		heap.push("!");
+		heap.push("@");
+		heap.push("#");
+		heap.push("$");
+
+		expect(heap.pop()).toBe("!");
+		expect(heap.pop()).toBe("#");
+		expect(heap.pop()).toBe("$");
+		expect(heap.pop()).toBe("@");
+	});
+
+	test("MinHeap stress test", () => {
+		const heap = new Heap(new MinHeap());
+		const items = Array.from({ length: 100 }, (_, i) => String.fromCharCode(65 + (i % 26)));
+
+		// Push all items
+		items.forEach((item) => heap.push(item));
+		expect(heap.length()).toBe(100);
+
+		// Verify they come out in sorted order
+		let prev = heap.pop();
+		expect(prev).toBeDefined();
+
+		while (heap.length() > 0) {
+			const current = heap.pop();
+			expect(current).toBeDefined();
+			if (prev != null && current != null) {
+				expect(prev <= current).toBe(true);
+			}
+			prev = current;
+		}
+	});
+});


### PR DESCRIPTION
This PR aim to have a deterministic topological sort otherwise 2 peer with the same hashgraph could nevertheless result in a different topological sort

- **chore: add topo sort deterministic test**
- **fix: use fake timers to have deterministic hash**
- **feat: add min heap to have deterministic hashgraph**
