### PR TITLE
fix: merge new vertices when drp is missing

### DIFF
--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -268,18 +268,23 @@ export class DRPObject implements DRPObjectBase {
 			try {
 				this.validateVertex(vertex);
 				const preComputeLca = this.computeLCA(vertex.dependencies);
-				const drp = this._computeDRP(
-					vertex.dependencies,
-					preComputeLca,
-					vertex.operation.drpType === DrpType.DRP ? vertex.operation : undefined
-				);
+
+				if (this.drp) {
+					const drp = this._computeDRP(
+						vertex.dependencies,
+						preComputeLca,
+						vertex.operation.drpType === DrpType.DRP ? vertex.operation : undefined
+					);
+					this._setDRPState(vertex, preComputeLca, this._getDRPState(drp));
+				}
+
 				const acl = this._computeObjectACL(
 					vertex.dependencies,
 					preComputeLca,
 					vertex.operation.drpType === DrpType.ACL ? vertex.operation : undefined
 				);
-				this._setDRPState(vertex, preComputeLca, this._getDRPState(drp));
 				this._setObjectACLState(vertex, preComputeLca, this._getDRPState(acl));
+
 				this.hashGraph.addVertex(vertex);
 				this._initializeFinalityState(vertex.hash, acl);
 				newVertices.push(vertex);

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -214,20 +214,6 @@ export class DRPObject implements DRPObjectBase {
 		return appliedOperationResult;
 	}
 
-	/* Merges the vertices into the hashgraph
-	 * Returns a tuple with a boolean indicating if there were
-	 * missing vertices and an array with the missing vertices
-	 */
-	merge(vertices: Vertex[]): [merged: boolean, missing: string[]] {
-		if (!this.hashGraph) {
-			throw new Error("Hashgraph is undefined");
-		}
-		if (!this.drp) {
-			return this._mergeWithoutDrp(vertices);
-		}
-		return this._mergeWithDrp(vertices);
-	}
-
 	validateVertex(vertex: Vertex) {
 		// Validate hash value
 		if (
@@ -262,9 +248,15 @@ export class DRPObject implements DRPObjectBase {
 		}
 	}
 
-	/* Merges the vertices into the hashgraph using DRP
+	/* Merges the vertices into the hashgraph
+	 * Returns a tuple with a boolean indicating if there were
+	 * missing vertices and an array with the missing vertices
 	 */
-	private _mergeWithDrp(vertices: Vertex[]): [merged: boolean, missing: string[]] {
+	merge(vertices: Vertex[]): [merged: boolean, missing: string[]] {
+		if (!this.hashGraph) {
+			throw new Error("Hashgraph is undefined");
+		}
+
 		const missing: Hash[] = [];
 		const newVertices: Vertex[] = [];
 		for (const vertex of vertices) {
@@ -298,35 +290,8 @@ export class DRPObject implements DRPObjectBase {
 
 		this.vertices = this.hashGraph.getAllVertices();
 		this._updateObjectACLState();
-		this._updateDRPState();
+		if (this.drp) this._updateDRPState();
 		this._notify("merge", newVertices);
-
-		return [missing.length === 0, missing];
-	}
-
-	/* Merges the vertices into the hashgraph without using DRP
-	 */
-	private _mergeWithoutDrp(vertices: Vertex[]): [merged: boolean, missing: string[]] {
-		const missing = [];
-		for (const vertex of vertices) {
-			if (!vertex.operation || this.hashGraph.vertices.has(vertex.hash)) {
-				continue;
-			}
-
-			try {
-				this.validateVertex(vertex);
-				this.hashGraph.addVertex({
-					hash: vertex.hash,
-					operation: vertex.operation,
-					dependencies: vertex.dependencies,
-					peerId: vertex.peerId,
-					timestamp: vertex.timestamp,
-					signature: vertex.signature,
-				});
-			} catch (_) {
-				missing.push(vertex.hash);
-			}
-		}
 
 		return [missing.length === 0, missing];
 	}
@@ -348,10 +313,6 @@ export class DRPObject implements DRPObjectBase {
 
 	// check if the given peer has write permission
 	private _checkWriterPermission(peerId: string, deps: Hash[]): boolean {
-		if (!this.drp) {
-			return (this.acl as ACL).query_isWriter(peerId);
-		}
-
 		const acl = this._computeObjectACL(deps);
 		return (acl as ACL).query_isWriter(peerId);
 	}


### PR DESCRIPTION
<!--
     For work-in-progress PRs, please open a Draft PR.

     Before submitting a PR, please ensure you've done the following:
     - 📖 Read Topology's Contributing Guide: https://github.com/topology-gg/.github/CONTRIBUTING.md
     - 📖 Read Topology's Code of Conduct: https://github.com/topology-gg/.github/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📗 Update any related documentation.

     TL;DR:
     - Use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/) for PR titles.
     - Link existing issues and PRs.
     - Provide tests for your changes.
     - Update any related documentation.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
* remove function `mergeWithoutDrp`
* update logic when store drp state and acl state to make code more readable
* check if the drp exists before apply operation and store/update drp state
* update `_checkWriterPermission` because we still have the acl state even if the drp is missing

## Related Issues and PRs

- Related: #
- Closes: #452 

## Added/updated tests?

- [ ] Yes
- [x] No, because why: just merged two functions. current tests covered all the cases
- [ ] I need help with writing tests

## Additional Info

_add instructions or screenshots on what you might think is relevant or instructions on how to manually test it_

## [optional] Do we need to perform any post-deployment tasks?
