### PR TITLE
refactor: remove unuse transport

### DIFF
--- a/packages/network/src/node.ts
+++ b/packages/network/src/node.ts
@@ -192,11 +192,9 @@ export class DRPNetworkNode {
 			transports: [
 				circuitRelayTransport(),
 				webRTC(),
-				webRTCDirect(),
 				webSockets({
 					filter: filters.all,
 				}),
-				webTransport(),
 			],
 		});
 		log.info(

--- a/packages/network/src/node.ts
+++ b/packages/network/src/node.ts
@@ -25,10 +25,9 @@ import {
 	type PubSubPeerDiscoveryComponents,
 	pubsubPeerDiscovery,
 } from "@libp2p/pubsub-peer-discovery";
-import { webRTC, webRTCDirect } from "@libp2p/webrtc";
+import { webRTC } from "@libp2p/webrtc";
 import { webSockets } from "@libp2p/websockets";
 import * as filters from "@libp2p/websockets/filters";
-import { webTransport } from "@libp2p/webtransport";
 import { type MultiaddrInput, multiaddr } from "@multiformats/multiaddr";
 import { WebRTC } from "@multiformats/multiaddr-matcher";
 import { Logger, type LoggerOptions } from "@ts-drp/logger";

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -6,13 +6,7 @@ import * as crypto from "node:crypto";
 import { ObjectACL } from "./acl/index.js";
 import type { ACL } from "./acl/interface.js";
 import { type FinalityConfig, FinalityStore } from "./finality/index.js";
-import {
-	type Hash,
-	HashGraph,
-	type Operation,
-	type ResolveConflictsType,
-	type Vertex,
-} from "./hashgraph/index.js";
+import { type Hash, HashGraph, type Operation, type Vertex } from "./hashgraph/index.js";
 import {
 	type DRP,
 	type DRPObjectCallback,

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -128,15 +128,6 @@ export class DRPObject implements ObjectPb.DRPObjectBase {
 		return object;
 	}
 
-	resolveConflicts(vertices: Vertex[]): ResolveConflictsType {
-		if (this.acl && vertices.some((v) => v.operation?.drpType === DrpType.ACL)) {
-			const acl = this.acl as ACL;
-			return acl.resolveConflicts(vertices);
-		}
-		const drp = this.drp as DRP;
-		return drp.resolveConflicts(vertices);
-	}
-
 	// This function is black magic, it allows us to intercept calls to the DRP object
 	proxyDRPHandler(vertexType: DrpType): ProxyHandler<object> {
 		// eslint-disable-next-line @typescript-eslint/no-this-alias


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Remove unused transport and ensure the protocol still work without them:
- webRTCDirect
- WebTransport

And remove unused function

## Related Issues and PRs

- Related: #
- Closes: #426 

## Added/updated tests?

- [ ] Yes
- [x] No, because why: just remove transport
- [ ] I need help with writing tests

## Additional Info

## [optional] Do we need to perform any post-deployment tasks?
