### PR TITLE
refactor: move peer id from drpObject to hashgraph

### DIFF
--- a/packages/object/src/hashgraph/index.ts
+++ b/packages/object/src/hashgraph/index.ts
@@ -1,13 +1,11 @@
-import type { Vertex_Operation as Operation, Vertex } from "@ts-drp/types";
+import { type Vertex_Operation as Operation, Vertex } from "@ts-drp/types";
 
 import { log } from "../index.js";
 import { BitSet } from "./bitset.js";
 import { linearizeMultipleSemantics } from "../linearize/multipleSemantics.js";
 import { linearizePairSemantics } from "../linearize/pairSemantics.js";
+import { computeHash } from "../utils/computeHash.js";
 import { ObjectSet } from "../utils/objectSet.js";
-
-// Reexporting the Vertex and Operation types from the protobuf file
-export type { Vertex, Operation };
 
 export type Hash = string;
 
@@ -103,6 +101,17 @@ export class HashGraph {
 		return this.resolveConflictsDRP
 			? this.resolveConflictsDRP(vertices)
 			: { action: ActionType.Nop };
+	}
+
+	createVertex(vertexOperation: Operation, vertexDependencies: Hash[]): Vertex {
+		const vertexTimestamp = Date.now();
+		return Vertex.create({
+			hash: computeHash(this.peerId, vertexOperation, vertexDependencies, vertexTimestamp),
+			peerId: this.peerId,
+			operation: vertexOperation,
+			dependencies: vertexDependencies,
+			timestamp: vertexTimestamp,
+		});
 	}
 
 	addToFrontier(vertex: Vertex) {

--- a/packages/object/src/hashgraph/index.ts
+++ b/packages/object/src/hashgraph/index.ts
@@ -103,14 +103,14 @@ export class HashGraph {
 			: { action: ActionType.Nop };
 	}
 
-	createVertex(vertexOperation: Operation, vertexDependencies: Hash[]): Vertex {
-		const vertexTimestamp = Date.now();
+	createVertex(operation: Operation, dependencies: Hash[]): Vertex {
+		const timestamp = Date.now();
 		return Vertex.create({
-			hash: computeHash(this.peerId, vertexOperation, vertexDependencies, vertexTimestamp),
+			hash: computeHash(this.peerId, operation, dependencies, timestamp),
 			peerId: this.peerId,
-			operation: vertexOperation,
-			dependencies: vertexDependencies,
-			timestamp: vertexTimestamp,
+			timestamp,
+			operation,
+			dependencies,
 		});
 	}
 

--- a/packages/object/src/hashgraph/index.ts
+++ b/packages/object/src/hashgraph/index.ts
@@ -106,8 +106,7 @@ export class HashGraph {
 			: { action: ActionType.Nop };
 	}
 
-	createVertex(operation: Operation, dependencies: Hash[]): Vertex {
-		const timestamp = Date.now();
+	createVertex(operation: Operation, dependencies: Hash[], timestamp: number): Vertex {
 		return Vertex.create({
 			hash: computeHash(this.peerId, operation, dependencies, timestamp),
 			peerId: this.peerId,

--- a/packages/object/src/hashgraph/index.ts
+++ b/packages/object/src/hashgraph/index.ts
@@ -7,6 +7,9 @@ import { linearizePairSemantics } from "../linearize/pairSemantics.js";
 import { computeHash } from "../utils/computeHash.js";
 import { ObjectSet } from "../utils/objectSet.js";
 
+// Reexporting the Vertex and Operation types from the protobuf file
+export type { Vertex, Operation };
+
 export type Hash = string;
 
 export enum OperationType {

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -172,6 +172,7 @@ export class DRPObject implements DRPObjectBase {
 		const vertexDependencies = this.hashGraph.getFrontier();
 		const vertexOperation = { drpType, opType: fn, value: args };
 		const preComputeLca = this.computeLCA(vertexDependencies);
+		const now = Date.now();
 		const preOperationDRP = isACL
 			? this._computeObjectACL(vertexDependencies)
 			: this._computeDRP(vertexDependencies);
@@ -196,7 +197,7 @@ export class DRPObject implements DRPObjectBase {
 			? [this._computeDRP(vertexDependencies, preComputeLca), clonedDRP as ACL]
 			: [clonedDRP as DRP, this._computeObjectACL(vertexDependencies, preComputeLca)];
 
-		const vertex = this.hashGraph.createVertex(vertexOperation, vertexDependencies);
+		const vertex = this.hashGraph.createVertex(vertexOperation, vertexDependencies, now);
 		this.hashGraph.addToFrontier(vertex);
 
 		this.hashGraph.addToFrontier(vertex);

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -1,5 +1,11 @@
 import { Logger, type LoggerOptions } from "@ts-drp/logger";
-import { DRPObjectBase, DRPState, DRPStateEntry, ObjectPb } from "@ts-drp/types";
+import {
+	DRPObjectBase,
+	DRPState,
+	DRPStateEntry,
+	type Vertex_Operation as Operation,
+	type Vertex,
+} from "@ts-drp/types";
 import { cloneDeep } from "es-toolkit";
 import { deepEqual } from "fast-equals";
 import * as crypto from "node:crypto";
@@ -7,7 +13,7 @@ import * as crypto from "node:crypto";
 import { ObjectACL } from "./acl/index.js";
 import type { ACL } from "./acl/interface.js";
 import { type FinalityConfig, FinalityStore } from "./finality/index.js";
-import { type Hash, HashGraph, type Operation, type Vertex } from "./hashgraph/index.js";
+import { type Hash, HashGraph } from "./hashgraph/index.js";
 import {
 	type DRP,
 	type DRPObjectCallback,
@@ -15,6 +21,7 @@ import {
 	DrpType,
 	type LcaAndOperations,
 } from "./interface.js";
+import { computeHash } from "./utils/computeHash.js";
 import { ObjectSet } from "./utils/objectSet.js";
 
 export * from "./utils/serializer.js";
@@ -33,7 +40,6 @@ export let log: Logger;
 
 export class DRPObject implements DRPObjectBase {
 	id: string;
-	peerId: string;
 	vertices: Vertex[] = [];
 	acl?: ProxyHandler<ACL>;
 	drp?: ProxyHandler<DRP>;
@@ -59,7 +65,6 @@ export class DRPObject implements DRPObjectBase {
 			throw new Error("Either publicCredential or acl must be provided to create a DRPObject");
 		}
 
-		this.peerId = options.peerId;
 		log = new Logger("drp::object", options.config?.log_config);
 		this.id =
 			options.id ??
@@ -77,9 +82,9 @@ export class DRPObject implements DRPObjectBase {
 			});
 		this.acl = new Proxy(objAcl, this.proxyDRPHandler(DrpType.ACL));
 		if (options.drp) {
-			this._initLocalDrpInstance(options.drp, objAcl);
+			this._initLocalDrpInstance(options.peerId, options.drp, objAcl);
 		} else {
-			this._initNonLocalDrpInstance(objAcl);
+			this._initNonLocalDrpInstance(options.peerId, objAcl);
 		}
 
 		this.aclStates = new Map([[HashGraph.rootHash, DRPState.create()]]);
@@ -91,10 +96,10 @@ export class DRPObject implements DRPObjectBase {
 		this.originalDRP = cloneDeep(options.drp);
 	}
 
-	private _initLocalDrpInstance(drp: DRP, acl: DRP) {
+	private _initLocalDrpInstance(peerId: string, drp: DRP, acl: DRP) {
 		this.drp = new Proxy(drp, this.proxyDRPHandler(DrpType.DRP));
 		this.hashGraph = new HashGraph(
-			this.peerId,
+			peerId,
 			acl.resolveConflicts.bind(acl),
 			drp.resolveConflicts.bind(drp),
 			drp.semanticsType
@@ -102,8 +107,8 @@ export class DRPObject implements DRPObjectBase {
 		this.vertices = this.hashGraph.getAllVertices();
 	}
 
-	private _initNonLocalDrpInstance(acl: DRP) {
-		this.hashGraph = new HashGraph(this.peerId, acl.resolveConflicts.bind(this.acl));
+	private _initNonLocalDrpInstance(peerId: string, acl: DRP) {
+		this.hashGraph = new HashGraph(peerId, acl.resolveConflicts.bind(this.acl));
 		this.vertices = this.hashGraph.getAllVertices();
 	}
 
@@ -167,7 +172,6 @@ export class DRPObject implements DRPObjectBase {
 		const vertexDependencies = this.hashGraph.getFrontier();
 		const vertexOperation = { drpType, opType: fn, value: args };
 		const preComputeLca = this.computeLCA(vertexDependencies);
-		const now = Date.now();
 		const preOperationDRP = isACL
 			? this._computeObjectACL(vertexDependencies)
 			: this._computeDRP(vertexDependencies);
@@ -192,13 +196,8 @@ export class DRPObject implements DRPObjectBase {
 			? [this._computeDRP(vertexDependencies, preComputeLca), clonedDRP as ACL]
 			: [clonedDRP as DRP, this._computeObjectACL(vertexDependencies, preComputeLca)];
 
-		const vertex = ObjectPb.Vertex.create({
-			hash: computeHash(this.peerId, vertexOperation, vertexDependencies, now),
-			peerId: this.peerId,
-			operation: vertexOperation,
-			dependencies: vertexDependencies,
-			timestamp: now,
-		});
+		const vertex = this.hashGraph.createVertex(vertexOperation, vertexDependencies);
+		this.hashGraph.addToFrontier(vertex);
 
 		this.hashGraph.addToFrontier(vertex);
 		this._setDRPState(vertex, preComputeLca, this._getDRPState(drp));
@@ -541,17 +540,6 @@ export class DRPObject implements DRPObjectBase {
 		this.aclStates.set(HashGraph.rootHash, { state: aclState });
 		this.drpStates.set(HashGraph.rootHash, { state: drpState });
 	}
-}
-
-function computeHash(
-	peerId: string,
-	operation: Operation | undefined,
-	deps: Hash[],
-	timestamp: number
-): Hash {
-	const serialized = JSON.stringify({ operation, deps, peerId, timestamp });
-	const hash = crypto.createHash("sha256").update(serialized).digest("hex");
-	return hash;
 }
 
 export function newVertex(

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -198,7 +198,6 @@ export class DRPObject implements DRPObjectBase {
 			: [clonedDRP as DRP, this._computeObjectACL(vertexDependencies, preComputeLca)];
 
 		const vertex = this.hashGraph.createVertex(vertexOperation, vertexDependencies, now);
-		this.hashGraph.addToFrontier(vertex);
 
 		this.hashGraph.addToFrontier(vertex);
 		this._setDRPState(vertex, preComputeLca, this._getDRPState(drp));

--- a/packages/object/src/interface.ts
+++ b/packages/object/src/interface.ts
@@ -1,6 +1,7 @@
 import { ObjectPb } from "@ts-drp/types";
+import { type Vertex_Operation as Operation, Vertex } from "@ts-drp/types";
 
-import type { Operation, ResolveConflictsType, SemanticsType, Vertex } from "./hashgraph/index.js";
+import type { ResolveConflictsType, SemanticsType } from "./hashgraph/index.js";
 import type { DRPObject } from "./index.js";
 
 export enum DrpType {

--- a/packages/object/src/linearize/multipleSemantics.ts
+++ b/packages/object/src/linearize/multipleSemantics.ts
@@ -1,10 +1,6 @@
-import {
-	ActionType,
-	type Hash,
-	type HashGraph,
-	type Operation,
-	type Vertex,
-} from "../hashgraph/index.js";
+import { type Vertex_Operation as Operation, Vertex } from "@ts-drp/types";
+
+import { ActionType, type Hash, type HashGraph } from "../hashgraph/index.js";
 import type { ObjectSet } from "../utils/objectSet.js";
 
 export function linearizeMultipleSemantics(

--- a/packages/object/src/linearize/pairSemantics.ts
+++ b/packages/object/src/linearize/pairSemantics.ts
@@ -1,4 +1,6 @@
-import { ActionType, type Hash, type HashGraph, type Operation } from "../hashgraph/index.js";
+import { type Vertex_Operation as Operation } from "@ts-drp/types";
+
+import { ActionType, type Hash, type HashGraph } from "../hashgraph/index.js";
 import type { ObjectSet } from "../utils/objectSet.js";
 
 export function linearizePairSemantics(

--- a/packages/object/src/utils/computeHash.ts
+++ b/packages/object/src/utils/computeHash.ts
@@ -1,7 +1,7 @@
+import type { Vertex_Operation as Operation } from "@ts-drp/types";
 import * as crypto from "node:crypto";
 
 import type { Hash } from "../hashgraph/index.js";
-import type { Vertex_Operation as Operation } from "../proto/drp/object/v1/object_pb.js";
 
 export function computeHash(
 	peerId: string,

--- a/packages/object/src/utils/computeHash.ts
+++ b/packages/object/src/utils/computeHash.ts
@@ -1,0 +1,15 @@
+import * as crypto from "node:crypto";
+
+import type { Hash } from "../hashgraph/index.js";
+import type { Vertex_Operation as Operation } from "../proto/drp/object/v1/object_pb.js";
+
+export function computeHash(
+	peerId: string,
+	operation: Operation | undefined,
+	deps: Hash[],
+	timestamp: number
+): Hash {
+	const serialized = JSON.stringify({ operation, deps, peerId, timestamp });
+	const hash = crypto.createHash("sha256").update(serialized).digest("hex");
+	return hash;
+}

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -1,9 +1,10 @@
 import { MapConflictResolution, MapDRP } from "@ts-drp/blueprints/src/Map/index.js";
 import { SetDRP } from "@ts-drp/blueprints/src/Set/index.js";
+import { Vertex } from "@ts-drp/types";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { ObjectACL } from "../src/acl/index.js";
-import { ActionType, SemanticsType, Vertex } from "../src/hashgraph/index.js";
+import { ActionType, SemanticsType } from "../src/hashgraph/index.js";
 import {
 	ACLGroup,
 	DRP,

--- a/packages/object/tests/linearize.test.ts
+++ b/packages/object/tests/linearize.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
 
-import { ActionType } from "../dist/src/hashgraph/index.js";
-import { SemanticsType } from "../dist/src/hashgraph/index.js";
+import { SemanticsType, ActionType } from "../dist/src/hashgraph/index.js";
 import { DrpType, HashGraph, newVertex, type Vertex } from "../src/index.js";
 import { linearizeMultipleSemantics } from "../src/linearize/multipleSemantics.js";
 import { linearizePairSemantics } from "../src/linearize/pairSemantics.js";


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes the issue by moving `peerId` from `DRPObject` to `hashGraph`, ensuring proper vertex creation.

## Related Issues and PRs

- Related: #
- Closes: #384 

## Added/updated tests?

- [ ] Yes
- [x] No, because why: don't change any logic, just move `peerId`
- [ ] I need help with writing tests

## Additional Info

## [optional] Do we need to perform any post-deployment tasks?
