### PR TITLE
fix: pnpm install with v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,13 @@
 		"github": {
 			"release": true
 		}
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"@ipshipyard/node-datachannel",
+			"esbuild",
+			"pprof",
+			"protobufjs"
+		]
 	}
 }


### PR DESCRIPTION
Signed-off-by: Sacha Froment <sfroment42@gmail.com>

<!--
     For work-in-progress PRs, please open a Draft PR.

     Before submitting a PR, please ensure you've done the following:
     - 📖 Read Topology's Contributing Guide: https://github.com/topology-gg/.github/CONTRIBUTING.md
     - 📖 Read Topology's Code of Conduct: https://github.com/topology-gg/.github/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📗 Update any related documentation.

     TL;DR:
     - Use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/) for PR titles.
     - Link existing issues and PRs.
     - Provide tests for your changes.
     - Update any related documentation.
-->

## What type of PR is this?

<!-- Please delete options that are not relevant. -->

- [x] Bug Fix

## Description

When using pnpm10 you have to explicitly tell which module can run post install

## Related Issues and PRs

- Related: #
- Closes: #

## Added/updated tests?

<!-- Please delete options that are not relevant. -->

- [x] No, because why: I don't think this is use full to build a whole pnpm 10 pipeline just for this, we can just start to use it as well instead

## Additional Info

_add instructions or screenshots on what you might think is relevant or instructions on how to manually test it_

## [optional] Do we need to perform any post-deployment tasks?
