### PR TITLE
chore: disable doPX on non-bootstrap nodes, add acceptPXThreshold

### DIFF
--- a/packages/network/src/node.ts
+++ b/packages/network/src/node.ts
@@ -116,7 +116,7 @@ export class DRPNetworkNode {
 			identify: identify(),
 			identifyPush: identifyPush(),
 			pubsub: gossipsub({
-				doPX: true,
+				doPX: false, // Only enable doPX on trusted bootstrap nodes
 				allowPublishToZeroTopicPeers: true,
 				scoreParams: createPeerScoreParams({
 					IPColocationFactorWeight: 0,
@@ -133,6 +133,9 @@ export class DRPNetworkNode {
 					},
 				}),
 				fallbackToFloodsub: false,
+				scoreThresholds: {
+					acceptPXThreshold: 1000,
+				},
 			}),
 		};
 


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug Fix

## Description
Disabled `doPX` on non-bootstrap nodes
Add `accecptPXThreshold` to ensure only bootstrappers can supply new peers

## Related Issues and PRs

- Related: #389 
- Closes: #

## Added/updated tests?
no

## Additional Info
