### PR TITLE
refactor: remove addToFrontier

### DIFF
--- a/packages/object/src/hashgraph/index.ts
+++ b/packages/object/src/hashgraph/index.ts
@@ -107,34 +107,6 @@ export class HashGraph {
 		});
 	}
 
-	addToFrontier(vertex: Vertex) {
-		this.vertices.set(vertex.hash, vertex);
-		// Update forward edges
-		for (const dep of vertex.dependencies) {
-			if (!this.forwardEdges.has(dep)) {
-				this.forwardEdges.set(dep, []);
-			}
-			this.forwardEdges.get(dep)?.push(vertex.hash);
-		}
-
-		// Compute the distance of the vertex
-		const vertexDistance: VertexDistance = {
-			distance: Number.MAX_VALUE,
-			closestDependency: "",
-		};
-		for (const dep of vertex.dependencies) {
-			const depDistance = this.vertexDistances.get(dep);
-			if (depDistance && depDistance.distance + 1 < vertexDistance.distance) {
-				vertexDistance.distance = depDistance.distance + 1;
-				vertexDistance.closestDependency = dep;
-			}
-		}
-		this.vertexDistances.set(vertex.hash, vertexDistance);
-
-		this.frontier = [vertex.hash];
-		this.arePredecessorsFresh = false;
-	}
-
 	// Add a new vertex to the hashgraph.
 	addVertex(vertex: Vertex) {
 		this.vertices.set(vertex.hash, vertex);

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -208,7 +208,7 @@ export class DRPObject implements DRPObjectBase {
 
 		const vertex = this.hashGraph.createVertex(vertexOperation, vertexDependencies, now);
 
-		this.hashGraph.addToFrontier(vertex);
+		this.hashGraph.addVertex(vertex);
 		this._setDRPState(vertex, preComputeLca, this._getDRPState(drp));
 		this._setObjectACLState(vertex, preComputeLca, this._getDRPState(acl));
 		this._initializeFinalityState(vertex.hash, acl);


### PR DESCRIPTION
<!--
     For work-in-progress PRs, please open a Draft PR.

     Before submitting a PR, please ensure you've done the following:
     - 📖 Read Topology's Contributing Guide: https://github.com/topology-gg/.github/CONTRIBUTING.md
     - 📖 Read Topology's Code of Conduct: https://github.com/topology-gg/.github/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📗 Update any related documentation.

     TL;DR:
     - Use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/) for PR titles.
     - Link existing issues and PRs.
     - Provide tests for your changes.
     - Update any related documentation.
-->

## What type of PR is this?

<!-- Please delete options that are not relevant. -->

- [x] Refactor

## Description
Currently, the functions `addToFrontier` and `addVertex` are the same. Remove function `addToFrontier` and use `addVertex` when a new operation is applied locally to make it easier to maintain the codebase.

## Related Issues and PRs

- Closes: #441 

## Added/updated tests?

<!-- Please delete options that are not relevant. -->

- [x] No, because why: it's just a refactor. current tests covered it already.

## Additional Info

_add instructions or screenshots on what you might think is relevant or instructions on how to manually test it_

## [optional] Do we need to perform any post-deployment tasks?
