### PR TITLE
fix: writer permission check

### DIFF
--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -260,7 +260,10 @@ export class DRPObject implements DRPObjectBase, IDRPObject {
 		}
 
 		// Validate writer permission
-		if (!this._checkWriterPermission(vertex.peerId, vertex.dependencies)) {
+		if (
+			vertex.operation?.drpType === DrpType.DRP &&
+			!this._checkWriterPermission(vertex.peerId, vertex.dependencies)
+		) {
 			throw new Error(`Vertex ${vertex.peerId} does not have write permission.`);
 		}
 	}


### PR DESCRIPTION
<!--
     For work-in-progress PRs, please open a Draft PR.

     Before submitting a PR, please ensure you've done the following:
     - 📖 Read Topology's Contributing Guide: https://github.com/topology-gg/.github/CONTRIBUTING.md
     - 📖 Read Topology's Code of Conduct: https://github.com/topology-gg/.github/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📗 Update any related documentation.

     TL;DR:
     - Use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/) for PR titles.
     - Link existing issues and PRs.
     - Provide tests for your changes.
     - Update any related documentation.
-->

## What type of PR is this?

<!-- Please delete options that are not relevant. -->

- [x] Bug Fix

## Description
- Updated `validateVertex` function to only check writer permission when the `operation.drpType` is DRP.

## Added/updated tests?

<!-- Please delete options that are not relevant. -->

- [x] No, because why: currently we don't have a good way to test it with the ACL because `grant` and `revoke` operation need admin permission. i will add more tests #536 

