### PR TITLE
refactor: update linearization to return vertices

### DIFF
--- a/packages/object/src/hashgraph/index.ts
+++ b/packages/object/src/hashgraph/index.ts
@@ -210,10 +210,10 @@ export class HashGraph implements IHashGraph {
 		return result;
 	}
 
-	linearizeOperations(
+	linearizeVertices(
 		origin: Hash = HashGraph.rootHash,
 		subgraph: ObjectSet<string> = new ObjectSet(this.vertices.keys())
-	): Operation[] {
+	): Vertex[] {
 		switch (this.semanticsTypeDRP) {
 			case SemanticsType.pair:
 				return linearizePairSemantics(this, origin, subgraph);

--- a/packages/object/src/linearize/multipleSemantics.ts
+++ b/packages/object/src/linearize/multipleSemantics.ts
@@ -1,4 +1,4 @@
-import { ActionType, type Hash, type Operation, type Vertex } from "@ts-drp/types";
+import { ActionType, type Hash, type Vertex } from "@ts-drp/types";
 
 import { type HashGraph } from "../hashgraph/index.js";
 import type { ObjectSet } from "../utils/objectSet.js";
@@ -7,15 +7,15 @@ export function linearizeMultipleSemantics(
 	hashGraph: HashGraph,
 	origin: Hash,
 	subgraph: ObjectSet<string>
-): Operation[] {
+): Vertex[] {
 	const order = hashGraph.topologicalSort(true, origin, subgraph);
-	const result: Operation[] = [];
+	const result: Vertex[] = [];
 	// if there is no resolveConflicts function, we can just return the operations in topological order
 	if (!hashGraph.resolveConflictsACL && !hashGraph.resolveConflictsDRP) {
 		for (let i = 1; i < order.length; i++) {
-			const op = hashGraph.vertices.get(order[i])?.operation;
-			if (op && op.value !== null) {
-				result.push(op);
+			const vertex = hashGraph.vertices.get(order[i]);
+			if (vertex) {
+				result.push(vertex);
 			}
 		}
 		return result;
@@ -90,8 +90,10 @@ export function linearizeMultipleSemantics(
 		}
 
 		if (!dropped[i]) {
-			const op = hashGraph.vertices.get(order[i])?.operation;
-			if (op && op.value !== null) result.push(op);
+			const vertex = hashGraph.vertices.get(order[i]);
+			if (vertex) {
+				result.push(vertex);
+			}
 		}
 		i++;
 	}

--- a/packages/object/src/linearize/pairSemantics.ts
+++ b/packages/object/src/linearize/pairSemantics.ts
@@ -1,4 +1,4 @@
-import { ActionType, type Hash, type Operation } from "@ts-drp/types";
+import { ActionType, type Hash, type Vertex } from "@ts-drp/types";
 
 import { type HashGraph } from "../hashgraph/index.js";
 import type { ObjectSet } from "../utils/objectSet.js";
@@ -7,15 +7,15 @@ export function linearizePairSemantics(
 	hashGraph: HashGraph,
 	origin: Hash,
 	subgraph: ObjectSet<string>
-): Operation[] {
+): Vertex[] {
 	const order = hashGraph.topologicalSort(true, origin, subgraph);
-	const result: Operation[] = [];
+	const result: Vertex[] = [];
 	// if there is no resolveConflicts function, we can just return the operations in topological order
 	if (!hashGraph.resolveConflictsACL && !hashGraph.resolveConflictsDRP) {
 		for (let i = 1; i < order.length; i++) {
-			const op = hashGraph.vertices.get(order[i])?.operation;
-			if (op && op.value !== null) {
-				result.push(op);
+			const vertex = hashGraph.vertices.get(order[i]);
+			if (vertex) {
+				result.push(vertex);
 			}
 		}
 		return result;
@@ -65,8 +65,8 @@ export function linearizePairSemantics(
 
 		if (!dropped[i]) {
 			const vertex = hashGraph.vertices.get(order[i]);
-			if (vertex?.operation && vertex.operation.value !== null) {
-				result.push(vertex.operation);
+			if (vertex) {
+				result.push(vertex);
 			}
 		}
 	}

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -107,7 +107,7 @@ describe("HashGraph construction tests", () => {
 		obj2.merge(obj1.hashGraph.getAllVertices());
 		expect(selfCheckConstraints(obj2.hashGraph)).toBe(true);
 
-		const linearOps = obj2.hashGraph.linearizeOperations();
+		const linearOps = obj2.hashGraph.linearizeVertices();
 		expect(linearOps).toEqual([
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "add", value: [2], drpType: DrpType.DRP },
@@ -197,7 +197,7 @@ describe("HashGraph construction tests", () => {
 		}).toThrowError(`Vertex ${vertex.hash} has invalid dependency ${fakeRoot.hash}.`);
 		expect(selfCheckConstraints(obj1.hashGraph)).toBe(true);
 
-		const linearOps = obj1.hashGraph.linearizeOperations();
+		const linearOps = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [{ opType: "add", value: [1], drpType: DrpType.DRP }];
 		expect(linearOps).toEqual(expectedOps);
 	});
@@ -253,7 +253,7 @@ describe("HashGraph for SetDRP tests", () => {
 		drp1.delete(1);
 		expect(drp1.query_has(1)).toBe(false);
 
-		const linearOps = obj1.hashGraph.linearizeOperations();
+		const linearOps = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "delete", value: [1], drpType: DrpType.DRP },
@@ -283,7 +283,7 @@ describe("HashGraph for SetDRP tests", () => {
 		expect(drp1.query_has(1)).toBe(false);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeOperations();
+		const linearOps = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "delete", value: [1], drpType: DrpType.DRP },
@@ -313,7 +313,7 @@ describe("HashGraph for SetDRP tests", () => {
 		expect(drp1.query_has(2)).toBe(true);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeOperations();
+		const linearOps = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "add", value: [2], drpType: DrpType.DRP },
@@ -348,7 +348,7 @@ describe("HashGraph for SetDRP tests", () => {
 		expect(drp1.query_has(5)).toBe(false);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeOperations();
+		const linearOps = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "delete", value: [1], drpType: DrpType.DRP },
@@ -381,7 +381,7 @@ describe("HashGraph for SetDRP tests", () => {
 		expect(drp1.query_has(2)).toBe(true);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeOperations();
+		const linearOps = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "delete", value: [1], drpType: DrpType.DRP },
@@ -416,7 +416,7 @@ describe("HashGraph for SetDRP tests", () => {
 		expect(drp1.query_has(2)).toBe(false);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeOperations();
+		const linearOps = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "add", value: [2], drpType: DrpType.DRP },
@@ -442,13 +442,13 @@ describe("HashGraph for SetDRP tests", () => {
 		obj2.merge(obj1.hashGraph.getAllVertices());
 
 		const order1 = obj1.hashGraph.topologicalSort();
-		const linearizedOps1 = obj1.hashGraph.linearizeOperations();
+		const linearizedOps1 = obj1.hashGraph.linearizeVertices();
 		for (let i = 0; i < linearizedOps1.length; ++i) {
 			expect(linearizedOps1[i]).toBe(obj1.hashGraph.vertices.get(order1[i + 1])?.operation);
 		}
 
 		const order2 = obj2.hashGraph.topologicalSort();
-		const linearizedOps2 = obj2.hashGraph.linearizeOperations();
+		const linearizedOps2 = obj2.hashGraph.linearizeVertices();
 		for (let i = 0; i < linearizedOps2.length; ++i) {
 			expect(linearizedOps2[i]).toBe(obj2.hashGraph.vertices.get(order2[i + 1])?.operation);
 		}
@@ -476,7 +476,7 @@ describe("HashGraph for undefined operations tests", () => {
 
 		obj2.merge(obj1.hashGraph.getAllVertices());
 
-		const linearOps = obj2.hashGraph.linearizeOperations();
+		const linearOps = obj2.hashGraph.linearizeVertices();
 		// Should only have one, since we skipped the undefined operations
 		expect(linearOps).toEqual([{ opType: "add", value: [2], drpType: DrpType.DRP }]);
 	});
@@ -526,7 +526,7 @@ describe("Hashgraph and DRPObject merge without DRP tests", () => {
 		expect(drp1.query_has(2)).toBe(false);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeOperations();
+		const linearOps = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "add", value: [2], drpType: DrpType.DRP },

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -107,8 +107,8 @@ describe("HashGraph construction tests", () => {
 		obj2.merge(obj1.hashGraph.getAllVertices());
 		expect(selfCheckConstraints(obj2.hashGraph)).toBe(true);
 
-		const linearOps = obj2.hashGraph.linearizeVertices();
-		expect(linearOps).toEqual([
+		const linearizedVertices = obj2.hashGraph.linearizeVertices();
+		expect(linearizedVertices.map((vertex) => vertex.operation)).toEqual([
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "add", value: [2], drpType: DrpType.DRP },
 		] as Operation[]);
@@ -197,9 +197,9 @@ describe("HashGraph construction tests", () => {
 		}).toThrowError(`Vertex ${vertex.hash} has invalid dependency ${fakeRoot.hash}.`);
 		expect(selfCheckConstraints(obj1.hashGraph)).toBe(true);
 
-		const linearOps = obj1.hashGraph.linearizeVertices();
+		const linearizedVertices = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [{ opType: "add", value: [1], drpType: DrpType.DRP }];
-		expect(linearOps).toEqual(expectedOps);
+		expect(linearizedVertices.map((vertex) => vertex.operation)).toEqual(expectedOps);
 	});
 
 	test("Root vertex drp state should not be modified", () => {
@@ -253,12 +253,12 @@ describe("HashGraph for SetDRP tests", () => {
 		drp1.delete(1);
 		expect(drp1.query_has(1)).toBe(false);
 
-		const linearOps = obj1.hashGraph.linearizeVertices();
+		const linearizedVertices = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "delete", value: [1], drpType: DrpType.DRP },
 		];
-		expect(linearOps).toEqual(expectedOps);
+		expect(linearizedVertices.map((vertex) => vertex.operation)).toEqual(expectedOps);
 	});
 
 	test("Test: Add Two Concurrent Vertices With Same Value", () => {
@@ -283,12 +283,12 @@ describe("HashGraph for SetDRP tests", () => {
 		expect(drp1.query_has(1)).toBe(false);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeVertices();
+		const linearizedVertices = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "delete", value: [1], drpType: DrpType.DRP },
 		];
-		expect(linearOps).toEqual(expectedOps);
+		expect(linearizedVertices.map((vertex) => vertex.operation)).toEqual(expectedOps);
 	});
 
 	test("Test: Add Two Concurrent Vertices With Different Values", () => {
@@ -313,13 +313,13 @@ describe("HashGraph for SetDRP tests", () => {
 		expect(drp1.query_has(2)).toBe(true);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeVertices();
+		const linearizedVertices = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "add", value: [2], drpType: DrpType.DRP },
 			{ opType: "delete", value: [1], drpType: DrpType.DRP },
 		];
-		expect(linearOps).toEqual(expectedOps);
+		expect(linearizedVertices.map((vertex) => vertex.operation)).toEqual(expectedOps);
 	});
 
 	test("Test: Tricky Case", () => {
@@ -348,13 +348,13 @@ describe("HashGraph for SetDRP tests", () => {
 		expect(drp1.query_has(5)).toBe(false);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeVertices();
+		const linearizedVertices = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "delete", value: [1], drpType: DrpType.DRP },
 			{ opType: "add", value: [10], drpType: DrpType.DRP },
 		];
-		expect(linearOps).toEqual(expectedOps);
+		expect(linearizedVertices.map((vertex) => vertex.operation)).toEqual(expectedOps);
 	});
 
 	test("Test: Yuta Papa's Case", () => {
@@ -381,13 +381,13 @@ describe("HashGraph for SetDRP tests", () => {
 		expect(drp1.query_has(2)).toBe(true);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeVertices();
+		const linearizedVertices = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "delete", value: [1], drpType: DrpType.DRP },
 			{ opType: "add", value: [2], drpType: DrpType.DRP },
 		];
-		expect(linearOps).toEqual(expectedOps);
+		expect(linearizedVertices.map((vertex) => vertex.operation)).toEqual(expectedOps);
 	});
 
 	test("Test: Joao's latest brain teaser", () => {
@@ -416,16 +416,16 @@ describe("HashGraph for SetDRP tests", () => {
 		expect(drp1.query_has(2)).toBe(false);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeVertices();
+		const linearizedVertices = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "add", value: [2], drpType: DrpType.DRP },
 			{ opType: "delete", value: [2], drpType: DrpType.DRP },
 		];
-		expect(linearOps).toEqual(expectedOps);
+		expect(linearizedVertices.map((vertex) => vertex.operation)).toEqual(expectedOps);
 	});
 
-	test("Should return topological sort order when linearizing operations", () => {
+	test("Should return topological sort order when linearizing vertices", () => {
 		const drp1 = obj1.drp as SetDRP<number>;
 		const drp2 = obj2.drp as SetDRP<number>;
 
@@ -442,15 +442,19 @@ describe("HashGraph for SetDRP tests", () => {
 		obj2.merge(obj1.hashGraph.getAllVertices());
 
 		const order1 = obj1.hashGraph.topologicalSort();
-		const linearizedOps1 = obj1.hashGraph.linearizeVertices();
-		for (let i = 0; i < linearizedOps1.length; ++i) {
-			expect(linearizedOps1[i]).toBe(obj1.hashGraph.vertices.get(order1[i + 1])?.operation);
+		const linearizedVertices1 = obj1.hashGraph.linearizeVertices();
+		for (let i = 0; i < linearizedVertices1.length; ++i) {
+			expect(linearizedVertices1[i].operation).toBe(
+				obj1.hashGraph.vertices.get(order1[i + 1])?.operation
+			);
 		}
 
 		const order2 = obj2.hashGraph.topologicalSort();
-		const linearizedOps2 = obj2.hashGraph.linearizeVertices();
-		for (let i = 0; i < linearizedOps2.length; ++i) {
-			expect(linearizedOps2[i]).toBe(obj2.hashGraph.vertices.get(order2[i + 1])?.operation);
+		const linearizedVertices2 = obj2.hashGraph.linearizeVertices();
+		for (let i = 0; i < linearizedVertices2.length; ++i) {
+			expect(linearizedVertices2[i].operation).toBe(
+				obj2.hashGraph.vertices.get(order2[i + 1])?.operation
+			);
 		}
 	});
 });
@@ -476,9 +480,11 @@ describe("HashGraph for undefined operations tests", () => {
 
 		obj2.merge(obj1.hashGraph.getAllVertices());
 
-		const linearOps = obj2.hashGraph.linearizeVertices();
+		const linearizedVertices = obj2.hashGraph.linearizeVertices();
 		// Should only have one, since we skipped the undefined operations
-		expect(linearOps).toEqual([{ opType: "add", value: [2], drpType: DrpType.DRP }]);
+		expect(linearizedVertices.map((vertex) => vertex.operation)).toEqual([
+			{ opType: "add", value: [2], drpType: DrpType.DRP },
+		]);
 	});
 });
 
@@ -526,13 +532,13 @@ describe("Hashgraph and DRPObject merge without DRP tests", () => {
 		expect(drp1.query_has(2)).toBe(false);
 		expect(obj1.hashGraph.vertices).toEqual(obj2.hashGraph.vertices);
 
-		const linearOps = obj1.hashGraph.linearizeVertices();
+		const linearizedVertices = obj1.hashGraph.linearizeVertices();
 		const expectedOps: Operation[] = [
 			{ opType: "add", value: [1], drpType: DrpType.DRP },
 			{ opType: "add", value: [2], drpType: DrpType.DRP },
 			{ opType: "delete", value: [2], drpType: DrpType.DRP },
 		];
-		expect(linearOps).toEqual(expectedOps);
+		expect(linearizedVertices.map((vertex) => vertex.operation)).toEqual(expectedOps);
 
 		obj3.merge(obj1.hashGraph.getAllVertices());
 		expect(obj3.hashGraph.vertices).toEqual(obj1.hashGraph.vertices);

--- a/packages/object/tests/linearize.test.ts
+++ b/packages/object/tests/linearize.test.ts
@@ -60,7 +60,7 @@ describe("Linearize correctly", () => {
 		);
 		const expectedOrder = [1, 0, 3, 2, 4, 5, 7, 6, 8, 9];
 		for (let i = 0; i < 10; i++) {
-			expect(order[i].value).toStrictEqual([expectedOrder[i]]);
+			expect(order[i].operation?.value).toStrictEqual([expectedOrder[i]]);
 		}
 	});
 
@@ -129,7 +129,7 @@ describe("Linearize correctly", () => {
 		);
 		const expectedOrder = [4, 0, 8, 2, 6];
 		for (let i = 0; i < 5; i++) {
-			expect(order[i].value).toStrictEqual([expectedOrder[i]]);
+			expect(order[i].operation?.value).toStrictEqual([expectedOrder[i]]);
 		}
 	});
 });
@@ -190,7 +190,7 @@ describe("linearizeMultipleSemantics", () => {
 		hashGraph.getAllVertices().forEach((vertex) => subgraph.add(vertex.hash));
 
 		const result = linearizeMultipleSemantics(hashGraph, origin, subgraph);
-		expect(result.map((op) => op.value)).toEqual([[1], [2]]);
+		expect(result.map((vertex) => vertex.operation?.value)).toEqual([[1], [2]]);
 	});
 
 	test("should handle concurrent operations with conflict resolution", () => {
@@ -302,7 +302,7 @@ describe("linearizeMultipleSemantics", () => {
 		hashGraph.getAllVertices().forEach((vertex) => subgraph.add(vertex.hash));
 
 		const result = linearizeMultipleSemantics(hashGraph, origin, subgraph);
-		expect(result.map((op) => op.value)).toEqual([[3], [5], [6]]);
+		expect(result.map((vertex) => vertex.operation?.value)).toEqual([[3], [5], [6]]);
 	});
 
 	test("should handle operations with null values", () => {
@@ -324,7 +324,7 @@ describe("linearizeMultipleSemantics", () => {
 				"",
 				{
 					opType: "set",
-					value: null,
+					value: [1],
 					drpType: DrpType.DRP,
 				},
 				hashGraph.getFrontier(),
@@ -351,7 +351,7 @@ describe("linearizeMultipleSemantics", () => {
 		hashGraph.getAllVertices().forEach((vertex) => subgraph.add(vertex.hash));
 
 		const result = linearizeMultipleSemantics(hashGraph, origin, subgraph);
-		expect(result.map((op) => op.value)).toEqual([[2]]);
+		expect(result.map((vertex) => vertex.operation?.value)).toEqual([[1], [2]]);
 	});
 
 	test("should handle empty subgraph", () => {
@@ -407,10 +407,10 @@ describe("linearizeMultipleSemantics", () => {
 		}
 
 		const subgraph = new ObjectSet<string>(hashGraph.vertices.keys());
-		const linearizedOps = linearizePairSemantics(hashGraph, HashGraph.rootHash, subgraph);
+		const linearizedVertices = linearizePairSemantics(hashGraph, HashGraph.rootHash, subgraph);
 		const order = hashGraph.topologicalSort(true);
-		for (let i = 0; i < linearizedOps.length; i++) {
-			expect(linearizedOps[i]).equal(hashGraph.vertices.get(order[i + 1])?.operation);
+		for (let i = 0; i < linearizedVertices.length; i++) {
+			expect(linearizedVertices[i]).equal(hashGraph.vertices.get(order[i + 1]));
 		}
 	});
 });

--- a/packages/types/src/object.ts
+++ b/packages/types/src/object.ts
@@ -4,16 +4,11 @@ import { type IFinalityStore } from "./finality.js";
 import { type IHashGraph } from "./hashgraph.js";
 import { type LoggerOptions } from "./logger.js";
 import { type IMetrics } from "./metrics.js";
-import {
-	type DRPObjectBase,
-	type DRPState,
-	type Vertex_Operation as Operation,
-	type Vertex,
-} from "./proto/drp/v1/object_pb.js";
+import { type DRPObjectBase, type DRPState, type Vertex } from "./proto/drp/v1/object_pb.js";
 
-export interface LcaAndOperations {
+export interface LowestCommonAncestorResult {
 	lca: string;
-	linearizedOperations: Operation[];
+	linearizedVertices: Vertex[];
 }
 
 export interface IDRPObject extends DRPObjectBase {


### PR DESCRIPTION
<!--
     For work-in-progress PRs, please open a Draft PR.

     Before submitting a PR, please ensure you've done the following:
     - 📖 Read Topology's Contributing Guide: https://github.com/topology-gg/.github/CONTRIBUTING.md
     - 📖 Read Topology's Code of Conduct: https://github.com/topology-gg/.github/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📗 Update any related documentation.

     TL;DR:
     - Use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/) for PR titles.
     - Link existing issues and PRs.
     - Provide tests for your changes.
     - Update any related documentation.
-->

## What type of PR is this?

<!-- Please delete options that are not relevant. -->

- [x] Refactor

## Related Issues and PRs
- Related: #489 #551 
## Description
- Reason:
To expose the peerId that created the operations, the solution is that we will add a new attribute `context` to the DRP. Everytime before applying an operation to the DRP, we will update `DRP.context`value and the DRP devs can access this value using `this.value.peerId`.
When computing the vertex state, we apply operations to the DRP in linearized order and lack the caller's value, which is an attribute of the vertex instead of the operation. Therefore, i proposed to update the linearization functions to return vertices instead of opearations.

- Updated `linearizeVertices`, `linearizePairSemantics`, `linearizeMultipleSemantics` to return `Vertex[]` instead of `Operation[]`.
- Updated `DRPObject` with these changes`
- Changed `LcaAndOperations` to `LowestCommonAncestorResult`.
- Updated relevant tests.

## Added/updated tests?

<!-- Please delete options that are not relevant. -->

- [x] Yes

## Additional Info

_add instructions or screenshots on what you might think is relevant or instructions on how to manually test it_

## [optional] Do we need to perform any post-deployment tasks?
