### PR TITLE
fix: bt node env parsing

### DIFF
--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -2,6 +2,8 @@ import type { DRPNodeConfig } from "@ts-drp/types";
 import * as dotenv from "dotenv";
 import fs from "node:fs";
 
+dotenv.config();
+
 function parseCommaSeparatedValue(value: string | undefined): string[] | undefined {
 	if (value === undefined) return undefined;
 	return value === "" ? [] : value.split(",");
@@ -19,8 +21,6 @@ export function loadConfig(configPath?: string | undefined): DRPNodeConfig | und
 			throw error;
 		}
 	}
-
-	dotenv.config();
 
 	const hasEnvConfig = [
 		"LISTEN_ADDRESSES",

--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -2,8 +2,6 @@ import type { DRPNodeConfig } from "@ts-drp/types";
 import * as dotenv from "dotenv";
 import fs from "node:fs";
 
-dotenv.config();
-
 function parseCommaSeparatedValue(value: string | undefined): string[] | undefined {
 	if (value === undefined) return undefined;
 	return value === "" ? [] : value.split(",");
@@ -21,6 +19,8 @@ export function loadConfig(configPath?: string | undefined): DRPNodeConfig | und
 			throw error;
 		}
 	}
+
+	dotenv.config();
 
 	const hasEnvConfig = [
 		"LISTEN_ADDRESSES",

--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -21,9 +21,8 @@ export function loadConfig(configPath?: string | undefined): DRPNodeConfig | und
 				? process.env.ANNOUNCE_ADDRESSES.split(",")
 				: undefined,
 			bootstrap: process.env.BOOTSTRAP ? process.env.BOOTSTRAP === "true" : undefined,
-			bootstrap_peers: process.env.BOOTSTRAP_PEERS
-				? process.env.BOOTSTRAP_PEERS.split(",")
-				: undefined,
+			bootstrap_peers:
+				process.env.BOOTSTRAP_PEERS != null ? process.env.BOOTSTRAP_PEERS.split(",") : undefined,
 			browser_metrics: process.env.BROWSER_METRICS
 				? process.env.BROWSER_METRICS === "true"
 				: undefined,

--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -2,36 +2,51 @@ import type { DRPNodeConfig } from "@ts-drp/types";
 import * as dotenv from "dotenv";
 import fs from "node:fs";
 
+function parseCommaSeparatedValue(value: string | undefined): string[] | undefined {
+	if (value === undefined) return undefined;
+	return value === "" ? [] : value.split(",");
+}
+
 export function loadConfig(configPath?: string | undefined): DRPNodeConfig | undefined {
 	let config: DRPNodeConfig | undefined;
 
 	if (configPath) {
-		config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-		return config;
+		try {
+			config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+			return config;
+		} catch (error) {
+			console.error(`Failed to load config from ${configPath}:`, error);
+			throw error;
+		}
 	}
 
-	const result = dotenv.config();
-	if (!result.error) {
-		config = {};
-		config.network_config = {
-			listen_addresses: process.env.LISTEN_ADDRESSES
-				? process.env.LISTEN_ADDRESSES.split(",")
-				: undefined,
-			announce_addresses: process.env.ANNOUNCE_ADDRESSES
-				? process.env.ANNOUNCE_ADDRESSES.split(",")
-				: undefined,
-			bootstrap: process.env.BOOTSTRAP ? process.env.BOOTSTRAP === "true" : undefined,
-			bootstrap_peers:
-				process.env.BOOTSTRAP_PEERS != null ? process.env.BOOTSTRAP_PEERS.split(",") : undefined,
-			browser_metrics: process.env.BROWSER_METRICS
-				? process.env.BROWSER_METRICS === "true"
-				: undefined,
-		};
-		config.keychain_config = {
-			private_key_seed: process.env.PRIVATE_KEY_SEED ? process.env.PRIVATE_KEY_SEED : undefined,
-		};
-		return config;
+	dotenv.config();
+
+	const hasEnvConfig = [
+		"LISTEN_ADDRESSES",
+		"ANNOUNCE_ADDRESSES",
+		"BOOTSTRAP",
+		"BOOTSTRAP_PEERS",
+		"BROWSER_METRICS",
+		"PRIVATE_KEY_SEED",
+	].some((key) => process.env[key] !== undefined);
+
+	if (!hasEnvConfig) {
+		return undefined;
 	}
 
+	config = {};
+	config.network_config = {
+		listen_addresses: parseCommaSeparatedValue(process.env.LISTEN_ADDRESSES),
+		announce_addresses: parseCommaSeparatedValue(process.env.ANNOUNCE_ADDRESSES),
+		bootstrap: process.env.BOOTSTRAP ? process.env.BOOTSTRAP === "true" : undefined,
+		bootstrap_peers: parseCommaSeparatedValue(process.env.BOOTSTRAP_PEERS),
+		browser_metrics: process.env.BROWSER_METRICS
+			? process.env.BROWSER_METRICS === "true"
+			: undefined,
+	};
+	config.keychain_config = {
+		private_key_seed: process.env.PRIVATE_KEY_SEED ? process.env.PRIVATE_KEY_SEED : undefined,
+	};
 	return config;
 }

--- a/packages/node/tests/load-config.test.ts
+++ b/packages/node/tests/load-config.test.ts
@@ -1,0 +1,129 @@
+import type { DRPNodeConfig } from "@ts-drp/types";
+import fs from "node:fs";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadConfig } from "../src/config.js";
+
+describe("loadConfig", () => {
+	const tempConfigPath = path.join(__dirname, "temp-config.json");
+
+	beforeEach(() => {
+		// Clear any existing env vars that might interfere with tests
+		delete process.env.LISTEN_ADDRESSES;
+		delete process.env.ANNOUNCE_ADDRESSES;
+		delete process.env.BOOTSTRAP;
+		delete process.env.BOOTSTRAP_PEERS;
+		delete process.env.BROWSER_METRICS;
+		delete process.env.PRIVATE_KEY_SEED;
+	});
+
+	afterEach(() => {
+		// Clean up temp file if it exists
+		if (fs.existsSync(tempConfigPath)) {
+			fs.unlinkSync(tempConfigPath);
+		}
+	});
+
+	it("should load config from JSON file when configPath is provided", () => {
+		const testConfig: DRPNodeConfig = {
+			network_config: {
+				listen_addresses: ["addr1", "addr2"],
+				announce_addresses: ["announce1"],
+				bootstrap: true,
+				bootstrap_peers: ["peer1", "peer2"],
+				browser_metrics: false,
+			},
+			keychain_config: {
+				private_key_seed: "test-seed",
+			},
+		};
+
+		fs.writeFileSync(tempConfigPath, JSON.stringify(testConfig));
+		const loadedConfig = loadConfig(tempConfigPath);
+		expect(loadedConfig).toEqual(testConfig);
+	});
+
+	it("should throw error when JSON file is invalid", () => {
+		fs.writeFileSync(tempConfigPath, "invalid json content");
+		expect(() => loadConfig(tempConfigPath)).toThrow();
+	});
+
+	it("should throw error when config file does not exist", () => {
+		const nonExistentPath = path.join(__dirname, "non-existent.json");
+		expect(() => loadConfig(nonExistentPath)).toThrow();
+	});
+
+	it("should load config from environment variables when no configPath is provided", () => {
+		process.env.LISTEN_ADDRESSES = "addr1,addr2";
+		process.env.ANNOUNCE_ADDRESSES = "announce1";
+		process.env.BOOTSTRAP_PEERS = "peer1,peer2";
+		process.env.BROWSER_METRICS = "false";
+		process.env.PRIVATE_KEY_SEED = "test-seed";
+
+		const expectedConfig: DRPNodeConfig = {
+			network_config: {
+				listen_addresses: ["addr1", "addr2"],
+				announce_addresses: ["announce1"],
+				bootstrap: undefined,
+				bootstrap_peers: ["peer1", "peer2"],
+				browser_metrics: false,
+			},
+			keychain_config: {
+				private_key_seed: "test-seed",
+			},
+		};
+
+		const loadedConfig = loadConfig();
+		expect(loadedConfig).toEqual(expectedConfig);
+	});
+
+	it("should handle missing environment variables by setting them to undefined", () => {
+		process.env.LISTEN_ADDRESSES = "addr1,addr2";
+		process.env.BOOTSTRAP = "true";
+		process.env.BOOTSTRAP_PEERS = "";
+
+		const expectedConfig: DRPNodeConfig = {
+			network_config: {
+				listen_addresses: ["addr1", "addr2"],
+				announce_addresses: undefined,
+				bootstrap: true,
+				bootstrap_peers: [],
+				browser_metrics: undefined,
+			},
+			keychain_config: {
+				private_key_seed: undefined,
+			},
+		};
+
+		const loadedConfig = loadConfig();
+		expect(loadedConfig).toEqual(expectedConfig);
+	});
+
+	it("should return undefined when no environment variables are set", () => {
+		const loadedConfig = loadConfig();
+		expect(loadedConfig).toBeUndefined();
+	});
+
+	it("should handle boolean environment variables correctly", () => {
+		process.env.LISTEN_ADDRESSES = "addr1";
+		process.env.BOOTSTRAP = "false";
+		process.env.BROWSER_METRICS = "anything-non-true";
+
+		const expectedConfig: DRPNodeConfig = {
+			network_config: {
+				listen_addresses: ["addr1"],
+				announce_addresses: undefined,
+				bootstrap: false,
+				bootstrap_peers: undefined,
+				browser_metrics: false,
+			},
+			keychain_config: {
+				private_key_seed: undefined,
+			},
+		};
+
+		const loadedConfig = loadConfig();
+		expect(loadedConfig).toEqual(expectedConfig);
+	});
+});


### PR DESCRIPTION
Signed-off-by: Sacha Froment <sfroment42@gmail.com>

<!--
     For work-in-progress PRs, please open a Draft PR.

     Before submitting a PR, please ensure you've done the following:
     - 📖 Read Topology's Contributing Guide: https://github.com/topology-gg/.github/CONTRIBUTING.md
     - 📖 Read Topology's Code of Conduct: https://github.com/topology-gg/.github/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📗 Update any related documentation.

     TL;DR:
     - Use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/) for PR titles.
     - Link existing issues and PRs.
     - Provide tests for your changes.
     - Update any related documentation.
-->

## What type of PR is this?

<!-- Please delete options that are not relevant. -->

- [x] Bug Fix

## Description

If bootstrap peers is passed but empty string it will still be undefined instead of and empty array

## Related Issues and PRs

- Related: #
- Closes: #

## Added/updated tests?

<!-- Please delete options that are not relevant. -->

- [x] Yes

## Additional Info

_add instructions or screenshots on what you might think is relevant or instructions on how to manually test it_

## [optional] Do we need to perform any post-deployment tasks?
