### PR TITLE
feat: add logger template

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -20,7 +20,7 @@ export class Logger {
 		this.log.setLevel(config?.level || "info");
 		prefix.reg(loglevel);
 		prefix.apply(this.log, {
-			template: "%n",
+			template: config?.template ?? "%n",
 		});
 
 		for (const method of Object.keys(this.log)) {

--- a/packages/types/src/logger.ts
+++ b/packages/types/src/logger.ts
@@ -2,4 +2,5 @@ import type loglevel from "loglevel";
 
 export interface LoggerOptions {
 	level?: loglevel.LogLevelDesc;
+	template?: string;
 }


### PR DESCRIPTION
<!--
     For work-in-progress PRs, please open a Draft PR.

     Before submitting a PR, please ensure you've done the following:
     - 📖 Read Topology's Contributing Guide: https://github.com/topology-gg/.github/CONTRIBUTING.md
     - 📖 Read Topology's Code of Conduct: https://github.com/topology-gg/.github/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📗 Update any related documentation.

     TL;DR:
     - Use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/) for PR titles.
     - Link existing issues and PRs.
     - Provide tests for your changes.
     - Update any related documentation.
-->

## What type of PR is this?

<!-- Please delete options that are not relevant. -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds the `template` attribute to the logger, allowing users to customize the logger prefix. The following lines illustrate the difference when using `"[%t] %l: %n"` as the template.

Before:
```
drp::network ::start: running on: []
```

After
```
[07:00:10] INFO: drp::network ::start: running on: []
```
<!--
## Related Issues and PRs

- Related: #
- Closes: #
-->

## Usage

```ts
const node = new DRPNode({
    network_config: {
        bootstrap_peers,
        log_config: {
            template: "[%t] %l: %n"
        },
    },
    keychain_config: {
        private_key_seed: opts.seed,
    }
});
```

## Added/updated tests?

<!-- Please delete options that are not relevant. -->

- [ ] Yes
- [x] No, because why: this feature has been actively used in simulation
- [ ] I need help with writing tests

<!--
_add instructions or screenshots on what you might think is relevant or instructions on how to manually test it_

## [optional] Do we need to perform any post-deployment tasks?
-->