### PR TITLE
fix: message Q isActive need to be false at start

### DIFF
--- a/packages/message-queue/src/message-queue.ts
+++ b/packages/message-queue/src/message-queue.ts
@@ -7,7 +7,7 @@ import { Channel } from "./channel.js";
 export class MessageQueue<T> implements IMessageQueue<T> {
 	private readonly options: Required<IMessageQueueOptions>;
 	private channel: Channel<T>;
-	private isActive: boolean = true;
+	private isActive: boolean = false;
 	// List of subscriber handlers
 	private subscribers: Array<(message: T) => void | Promise<void>> = [];
 	// A flag to ensure the fanout loop starts only once


### PR DESCRIPTION
Signed-off-by: Sacha Froment <sfroment42@gmail.com>

<!--
     For work-in-progress PRs, please open a Draft PR.

     Before submitting a PR, please ensure you've done the following:
     - 📖 Read Topology's Contributing Guide: https://github.com/topology-gg/.github/CONTRIBUTING.md
     - 📖 Read Topology's Code of Conduct: https://github.com/topology-gg/.github/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📗 Update any related documentation.

     TL;DR:
     - Use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/) for PR titles.
     - Link existing issues and PRs.
     - Provide tests for your changes.
     - Update any related documentation.
-->

## What type of PR is this?

<!-- Please delete options that are not relevant. -->

- [x] Bug Fix

## Description

## Related Issues and PRs

- Related: #
- Closes: #

## Added/updated tests?

<!-- Please delete options that are not relevant. -->

- [x] No, because why: _justify why you didn't add tests_

## Additional Info

_add instructions or screenshots on what you might think is relevant or instructions on how to manually test it_

## [optional] Do we need to perform any post-deployment tasks?
