### PR TITLE
fix: try to have consistency in test

### DIFF
--- a/packages/node/tests/handlers.test.ts
+++ b/packages/node/tests/handlers.test.ts
@@ -177,14 +177,14 @@ describe("Handle message correctly", () => {
 	}, 10_000); // 10 seconds
 
 	test("should handle update attestation message correctly", async () => {
-		drpObjectNode2.drp?.add(5);
-		drpObjectNode2.drp?.add(10);
-		const hash = drpObjectNode2.vertices[1].hash;
-		expect(node2.objectStore.get(drpObjectNode2.id)?.finalityStore.getNumberOfSignatures(hash)).toBe(1);
 		const p = raceEvent(node2, NodeEventName.DRP_ATTESTATION_UPDATE, controller.signal, {
 			filter: (event: CustomEvent<ObjectId>) => event.detail.id === drpObjectNode2.id,
 		});
-		drpObjectNode2.drp?.add(6);
+		drpObjectNode2.drp?.add(5);
+
+		const hash = drpObjectNode2.vertices[1].hash;
+		expect(node2.objectStore.get(drpObjectNode2.id)?.finalityStore.getNumberOfSignatures(hash)).toBe(1);
+
 		await p;
 		expect(node2.objectStore.get(drpObjectNode2.id)?.finalityStore.getNumberOfSignatures(hash)).toBe(2);
 	}, 10_000); // 60 seconds

--- a/packages/node/tests/handlers.test.ts
+++ b/packages/node/tests/handlers.test.ts
@@ -182,8 +182,7 @@ describe("Handle message correctly", () => {
 			p7,
 		]);
 		expect(node3.objectStore.get(drpObjectNode2.id)?.vertices.length).toBe(5);
-	}, 20_000); // 10 seconds
-
+	}, 20_000); // 20 seconds
 	test("should handle update attestation message correctly", async () => {
 		const p = raceEvent(node2, NodeEventName.DRP_ATTESTATION_UPDATE, controller.signal, {
 			filter: (event: CustomEvent<ObjectId>) => event.detail.id === drpObjectNode2.id,

--- a/packages/node/tests/handlers.test.ts
+++ b/packages/node/tests/handlers.test.ts
@@ -4,7 +4,7 @@ import { DRPNetworkNode } from "@ts-drp/network";
 import { type DRPObject, ObjectACL } from "@ts-drp/object";
 import { type DRPNetworkNodeConfig, DrpType, NodeEventName, type ObjectId, Operation } from "@ts-drp/types";
 import { raceEvent } from "race-event";
-import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { DRPNode } from "../src/index.js";
 
@@ -115,11 +115,19 @@ describe("Handle message correctly", () => {
 		});
 	});
 
+	afterEach(async () => {
+		await bootstrapNode.stop();
+		await node1.networkNode.stop();
+		await node2.networkNode.stop();
+	});
+
 	test("should handle update message correctly", async () => {
 		const p = raceEvent(node1, NodeEventName.DRP_UPDATE, controller.signal, {
 			filter: (event: CustomEvent<ObjectId>) => event.detail.id === drpObjectNode2.id,
 		});
+
 		drpObjectNode2.drp?.add(5);
+
 		await p;
 		const expected_operations = node1.objectStore.get(drpObjectNode2.id)?.vertices.map((vertex) => {
 			return vertex.operation;
@@ -146,7 +154,6 @@ describe("Handle message correctly", () => {
 		await p4;
 		expect(drpObjectNode1?.vertices.length).toBe(5);
 		expect(drpObjectNode2.vertices.length).toBe(5);
-
 		const node3 = createNewNode("node3");
 
 		await node3.start();
@@ -158,10 +165,11 @@ describe("Handle message correctly", () => {
 		});
 
 		expect(node3.objectStore.get(drpObjectNode2.id)?.vertices.length).toBe(undefined);
-		const p5 = raceEvent(node2, NodeEventName.DRP_FETCH_STATE);
-		const p8 = raceEvent(node1, NodeEventName.DRP_FETCH_STATE);
+
 		const p6 = raceEvent(node3, NodeEventName.DRP_FETCH_STATE_RESPONSE, controller.signal);
 		const p7 = raceEvent(node3, NodeEventName.DRP_SYNC_ACCEPTED, controller.signal);
+		const p5 = raceEvent(node2, NodeEventName.DRP_FETCH_STATE);
+
 		await Promise.all([
 			node3.connectObject({
 				id: drpObjectNode2.id,
@@ -169,12 +177,12 @@ describe("Handle message correctly", () => {
 					peerId: node2.networkNode.peerId,
 				},
 			}),
-			Promise.race([p5, p8]),
+			p5,
 			p6,
 			p7,
 		]);
 		expect(node3.objectStore.get(drpObjectNode2.id)?.vertices.length).toBe(5);
-	}, 10_000); // 10 seconds
+	}, 20_000); // 10 seconds
 
 	test("should handle update attestation message correctly", async () => {
 		const p = raceEvent(node2, NodeEventName.DRP_ATTESTATION_UPDATE, controller.signal, {
@@ -187,11 +195,5 @@ describe("Handle message correctly", () => {
 
 		await p;
 		expect(node2.objectStore.get(drpObjectNode2.id)?.finalityStore.getNumberOfSignatures(hash)).toBe(2);
-	}, 10_000); // 60 seconds
-
-	afterAll(async () => {
-		await bootstrapNode.stop();
-		await node1.networkNode.stop();
-		await node2.networkNode.stop();
-	});
+	}, 20_000); // 20 seconds
 });


### PR DESCRIPTION
- **fix: we only want one ope and wait for an attestation update on the vertices of this test**
- **chore: increase a bit the timeout of flaky test**

<!--
     For work-in-progress PRs, please open a Draft PR.

     Before submitting a PR, please ensure you've done the following:
     - 📖 Read Topology's Contributing Guide: https://github.com/topology-gg/.github/CONTRIBUTING.md
     - 📖 Read Topology's Code of Conduct: https://github.com/topology-gg/.github/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📗 Update any related documentation.

     TL;DR:
     - Use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/) for PR titles.
     - Link existing issues and PRs.
     - Provide tests for your changes.
     - Update any related documentation.
-->

## What type of PR is this?

<!-- Please delete options that are not relevant. -->

- [x] Bug Fix

## Description

I've might have been a bit to hard reducing timeout from 60s to 10s let's try increasing this a bit and see how it goes.
Additionaly one other thing is the fix on the latest test we only want to add one thing and then wait for the attestation

## Related Issues and PRs

- Related: #
- Closes: #

## Added/updated tests?

<!-- Please delete options that are not relevant. -->

- [x] No, because why: _justify why you didn't add tests_

## Additional Info

_add instructions or screenshots on what you might think is relevant or instructions on how to manually test it_

## [optional] Do we need to perform any post-deployment tasks?
